### PR TITLE
Allow variables in strings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ There are two configuration options:
 
 Basic usage
 ^^^^^^^^^^^^^^^^^^
-You need to inicialize the app by doing
+You need to initialize the app by doing:
 
 .. code-block::python
 
@@ -67,6 +67,14 @@ This will return the message in current user's language. There's optional parame
 
     >>> locales.get_message('welcome', langauge='en')
     'Welcome'
+
+If you have optional replaceable variables in the string, you can also replace them using the get_message method. For example,
+
+.. code-block::python
+
+    # hello is defined as 'hello {name}'
+    >>> locales.get_message('hello',name='user')
+    'hello user'
 
 Storing messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/flask_jsonlocale.py
+++ b/flask_jsonlocale.py
@@ -50,13 +50,15 @@ class Locales(object):
             self._messages[language] = messages
         return messages
     
-    def get_message(self, message_code, language=None):
+    def get_message(self, message_code, language=None, **args):
         if language is None: language = self.get_locale()
         if language == 'qqx':
             return message_code
-        return self._get_messages(language=language).get(message_code,
+        message = self._get_messages(language=language).get(message_code,
             self._get_messages(language=self.app.config.get('DEFAULT_LANGUAGE')).get(message_code, "<%s>" % message_code)
         )
+        message = message.format(**args)
+        return message
     _ = get_message
     
     def get_locales(self):


### PR DESCRIPTION
Allows developers to have replaceable values in strings that are to be translated. 

For example,
```py
    # hello is defined as 'hello {name}'
    >>> locales.get_message('hello',name='user')
    'hello user'
```

This resolves task [T240801](https://phabricator.wikimedia.org/T240801)